### PR TITLE
Persisting across session / foundation for Keychain support 

### DIFF
--- a/src/capsule/BiometricSessionManager.ts
+++ b/src/capsule/BiometricSessionManager.ts
@@ -1,0 +1,39 @@
+import userManagementClient from './UserManagementClient'
+import { ChallengeStorage } from './ChallengeStorage'
+
+export default class BiometricSessionManager {
+  private userId: string
+  private biometricStorage: ChallengeStorage
+  public async setBiometrics() {
+    return await userManagementClient.addBiometrics(this.userId, {
+      publicKey: await this.biometricStorage.getPublicKey(),
+    })
+  }
+
+  constructor(userId: string, biometricStorage: ChallengeStorage) {
+    this.userId = userId
+    this.biometricStorage = biometricStorage
+  }
+
+  private cookie: string | undefined
+
+  public async refreshBiometricsIfNeeded() {
+    if (typeof this.cookie === 'string') {
+      // this is how cookie is represented. We do parsing "manually" to avoid employing additional libs
+      // Example cookie: capsule.sid=s%3Ad324cb79-96c8-4995-868b-4774ae2004ce.RZ2H%2BbendbOVXEBJ2tKVLatSh24SOxxQ%2F7A51lfdSoM; Path=/; Expires=Fri, 30 Dec 2022 18:31:47 GMT; HttpOnly; SameSite=Strict
+      const expDate = this.cookie.split?.(';')?.[2]?.split?.('=')?.[1]
+      const isValid = expDate && new Date(expDate).valueOf() - Date.now() > 30000 // 30 seconds threshold
+      if (isValid) {
+        return
+      }
+    }
+
+    const challenge = await userManagementClient.getBiometricsChallenge(this.userId)
+    const message = challenge.data.challenge
+    const signature = await this.biometricStorage.signChallenge(message)
+    const response = await userManagementClient.verifyBiometricsChallenge(this.userId, {
+      signature,
+    })
+    this.cookie = response.headers['set-cookie'][0]
+  }
+}

--- a/src/capsule/BiometricSessionManager.ts
+++ b/src/capsule/BiometricSessionManager.ts
@@ -21,7 +21,10 @@ export default class BiometricSessionManager {
     if (typeof this.cookie === 'string') {
       // this is how cookie is represented. We do parsing "manually" to avoid employing additional libs
       // Example cookie: capsule.sid=s%3Ad324cb79-96c8-4995-868b-4774ae2004ce.RZ2H%2BbendbOVXEBJ2tKVLatSh24SOxxQ%2F7A51lfdSoM; Path=/; Expires=Fri, 30 Dec 2022 18:31:47 GMT; HttpOnly; SameSite=Strict
-      const expDate = this.cookie.split?.(';')?.[2]?.split?.('=')?.[1]
+      const expDate = this.cookie
+        ?.split?.(';')
+        ?.find((entry) => entry.trim().startsWith('Expires'))
+        ?.split?.('=')?.[1]
       const isValid = expDate && new Date(expDate).valueOf() - Date.now() > 30000 // 30 seconds threshold
       if (isValid) {
         return

--- a/src/capsule/CapsuleSigner.ts
+++ b/src/capsule/CapsuleSigner.ts
@@ -31,11 +31,6 @@ export abstract class CapsuleBaseSigner implements Signer {
   private userId = 'fc347001-7ec1-4977-a109-e838b5f01c0b'
   private keyshareStorage: PrivateKeyStorage | undefined
   protected abstract getPrivateKeyStorage(account: string): PrivateKeyStorage
-  // static restoreFromAccount(account: string) {
-  //   const signer = new CapsuleSigner()
-  //   signer.account = account
-  // return signer
-  // }
 
   async loadKeyshare(keyshare: string) {
     await this.setAccount(keyshare)

--- a/src/capsule/CapsuleSigner.ts
+++ b/src/capsule/CapsuleSigner.ts
@@ -85,7 +85,6 @@ export abstract class CapsuleBaseSigner implements Signer {
   async setAccount(keyshare: string) {
     const address = await CapsuleSignerModule.getAddress(keyshare)
     this.account = normalizeAddressWith0x(address)
-    console.log('SET ACCOUNT KAKS')
   }
 
   async signRawTransaction(tx: CeloTx) {
@@ -150,7 +149,6 @@ export abstract class CapsuleBaseSigner implements Signer {
     Logger.info(`${TAG}@signTypedData`, 'protocolId ' + res.protocolId)
     Logger.info(`${TAG}@signTypedData`, `transaction ` + tx)
     const keyshare = await this.keyshareStorage?.getPrivateKey()
-    console.log({ keyshare }, this.account)
     const signatureHex = await CapsuleSignerModule.sendTransaction(res.protocolId, keyshare, tx)
 
     Logger.info(

--- a/src/capsule/CapsuleWallet.ts
+++ b/src/capsule/CapsuleWallet.ts
@@ -16,8 +16,7 @@ export abstract class CapsuleBaseWallet
   protected abstract getSignersStorage(): SignersStorage
   protected abstract getCapsuleSigner(): CapsuleBaseSigner
   private signersStorage = this.getSignersStorage()
-  // Called on init to load existing wallets
-  // Not applicable for CapsuleWallet
+
   async loadAccountSigners(): Promise<Map<string, CapsuleBaseSigner>> {
     const addressToSigner = new Map<string, CapsuleBaseSigner>()
     const nativeKeys = await this.signersStorage.getAccounts()

--- a/src/capsule/CapsuleWallet.ts
+++ b/src/capsule/CapsuleWallet.ts
@@ -7,7 +7,7 @@ import { ErrorMessages } from 'src/app/ErrorMessages'
 import { CapsuleBaseSigner, CapsuleReactNativeSigner } from 'src/capsule/CapsuleSigner'
 import Logger from 'src/utils/Logger'
 import { ReactNativeSignersStorage, SignersStorage } from './SignersStorage'
-import { ChallengeStorageDefault } from './ChallengeStorage'
+import { ChallengeReactNativeStorage, ChallengeStorage } from './ChallengeStorage'
 import userManagementClient from './UserManagementClient'
 
 const TAG = 'geth/CapsuleWallet'
@@ -17,6 +17,7 @@ export abstract class CapsuleBaseWallet
   implements UnlockableWallet {
   protected abstract getSignersStorage(): SignersStorage
   protected abstract getCapsuleSigner(): CapsuleBaseSigner
+  protected abstract getChallengeStorage(userId: string): ChallengeStorage
   private signersStorage = this.getSignersStorage()
 
   async loadAccountSigners(): Promise<Map<string, CapsuleBaseSigner>> {
@@ -32,7 +33,7 @@ export abstract class CapsuleBaseWallet
 
   // TODO remove me
   private userId = 'c67b0766-f339-4d86-9c82-fe2410b28460'
-  private biometricStorage = new ChallengeStorageDefault(this.userId)
+  private biometricStorage = this.getChallengeStorage(this.userId)
 
   public async setBiometrics() {
     return await userManagementClient.addBiometrics(this.userId, {
@@ -141,6 +142,10 @@ class CapsuleReactNativeWallet extends CapsuleBaseWallet {
 
   getSignersStorage(): SignersStorage {
     return new ReactNativeSignersStorage()
+  }
+
+  getChallengeStorage(userId: string): ChallengeStorage {
+    return new ChallengeReactNativeStorage(userId)
   }
 }
 

--- a/src/capsule/CapsuleWallet.ts
+++ b/src/capsule/CapsuleWallet.ts
@@ -8,7 +8,7 @@ import { CapsuleBaseSigner, CapsuleReactNativeSigner } from 'src/capsule/Capsule
 import Logger from 'src/utils/Logger'
 import { ReactNativeSignersStorage, SignersStorage } from './SignersStorage'
 import { ChallengeReactNativeStorage, ChallengeStorage } from './ChallengeStorage'
-import userManagementClient from './UserManagementClient'
+import BiometricSessionManager from './BiometricSessionManager'
 
 const TAG = 'geth/CapsuleWallet'
 
@@ -19,6 +19,13 @@ export abstract class CapsuleBaseWallet
   protected abstract getCapsuleSigner(): CapsuleBaseSigner
   protected abstract getChallengeStorage(userId: string): ChallengeStorage
   private signersStorage = this.getSignersStorage()
+  // TODO remove me
+  private userId = 'c67b0766-f339-4d86-9c82-fe2410b28460'
+  // @ts-ignore
+  private biometricSessionManager = new BiometricSessionManager(
+    this.userId,
+    this.getChallengeStorage(this.userId)
+  )
 
   async loadAccountSigners(): Promise<Map<string, CapsuleBaseSigner>> {
     const addressToSigner = new Map<string, CapsuleBaseSigner>()
@@ -29,37 +36,6 @@ export abstract class CapsuleBaseWallet
       addressToSigner.set(nativeKey, signer)
     }
     return addressToSigner
-  }
-
-  // TODO remove me
-  private userId = 'c67b0766-f339-4d86-9c82-fe2410b28460'
-  private biometricStorage = this.getChallengeStorage(this.userId)
-
-  public async setBiometrics() {
-    return await userManagementClient.addBiometrics(this.userId, {
-      publicKey: await this.biometricStorage.getPublicKey(),
-    })
-  }
-
-  private cookie: string | undefined
-
-  public async refreshBiometricsIfNeeded() {
-    if (typeof this.cookie === 'string') {
-      // this is how cookie is represented. We do parsing "manually" to avoid employing additional libs
-      // Example cookie: capsule.sid=s%3Ad324cb79-96c8-4995-868b-4774ae2004ce.RZ2H%2BbendbOVXEBJ2tKVLatSh24SOxxQ%2F7A51lfdSoM; Path=/; Expires=Fri, 30 Dec 2022 18:31:47 GMT; HttpOnly; SameSite=Strict
-      const expDate = this.cookie.split?.(';')?.[2]?.split?.('=')?.[1]
-      const isValid = expDate && new Date(expDate).valueOf() - Date.now() > 30000 // 30 seconds threshold
-      if (isValid) {
-        return
-      }
-    }
-    const challenge = await userManagementClient.getBiometricsChallenge(this.userId)
-    const message = challenge.data.challenge
-    const signature = await this.biometricStorage.signChallenge(message)
-    const response = await userManagementClient.verifyBiometricsChallenge(this.userId, {
-      signature,
-    })
-    this.cookie = response.headers['set-cookie'][0]
   }
 
   async getKeyshare(address: string): Promise<string> {

--- a/src/capsule/CapsuleWallet.ts
+++ b/src/capsule/CapsuleWallet.ts
@@ -26,11 +26,13 @@ export class CapsuleWallet extends RemoteWallet<CapsuleSigner> implements Unlock
   }
 
   async addAccount(privateKey: string): Promise<string> {
+    console.log('setting up privateKey', privateKey)
     const signer = new CapsuleSigner()
     if (!privateKey) {
       Logger.info(`${TAG}@addAccount`, `Creating a new account`)
       privateKey = await signer.generateKeyshare()
       Logger.info(`${TAG}@addAccount`, privateKey)
+      signer.loadKeyshare(privateKey)
     } else {
       Logger.info(`${TAG}@addAccount`, `Adding a previously created account`)
       signer.loadKeyshare(privateKey)

--- a/src/capsule/ChallengeStorage.ts
+++ b/src/capsule/ChallengeStorage.ts
@@ -23,7 +23,7 @@ export interface Signature {
 const ec = new elliptic.ec('p256')
 
 const privateKey = '202d73cbde65f547c75613ace311393ac97f2556cbe3aca32bf48eb84ec2198c'
-export class ChallengeStorageDefault extends ChallengeStorage {
+export class ChallengeReactNativeStorage extends ChallengeStorage {
   async getPublicKey(): Promise<string> {
     return '0483326f8677519eace4e8db81722399ac4b581a91236656359ebf3621ad3186fdf2e1fa04c9929d577c36ffb9e2ef6cfe325d1da7ffa4d0a596bf88d7e335baf2'
   }

--- a/src/capsule/PrivateKeyStorage.ts
+++ b/src/capsule/PrivateKeyStorage.ts
@@ -1,23 +1,34 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
 export abstract class PrivateKeyStorage {
   public walletId: string
 
-  public abstract setPrivateKey(key: string): void
+  public abstract setPrivateKey(key: string): Promise<void>
 
-  public abstract getPrivateKey(): string
+  public abstract getPrivateKey(): Promise<string>
 
   public constructor(walletId: string) {
     this.walletId = walletId
   }
 }
 
-const PseudoKeychain = new Map<string, string>()
+// TODO make it a real keychain
+const TAG = '@CAPSULE/TODO-KEYCHAIN'
 
-export class PrivateKeyStorageDefault extends PrivateKeyStorage {
-  getPrivateKey(): string {
-    return PseudoKeychain.get(this.walletId) as string
+export class PrivateKeyStorageReactNative extends PrivateKeyStorage {
+  async getPrivateKey(): Promise<string> {
+    const storageString = await AsyncStorage.getItem(TAG)
+    console.log(storageString)
+    const storage = storageString ? JSON.parse(storageString) : {}
+    console.log('GETTING STORAGE', storage[this.walletId], this.walletId, storage)
+
+    return storage[this.walletId] as string
   }
 
-  setPrivateKey(key: string): void {
-    PseudoKeychain.set(this.walletId, key)
+  async setPrivateKey(key: string): Promise<void> {
+    const storageString = await AsyncStorage.getItem(TAG)
+    const storage = storageString ? JSON.parse(storageString) : {}
+    storage[this.walletId] = key
+    return await AsyncStorage.setItem(TAG, JSON.stringify(storage))
   }
 }

--- a/src/capsule/PrivateKeyStorage.ts
+++ b/src/capsule/PrivateKeyStorage.ts
@@ -18,10 +18,7 @@ const TAG = '@CAPSULE/TODO-KEYCHAIN'
 export class PrivateKeyStorageReactNative extends PrivateKeyStorage {
   async getPrivateKey(): Promise<string> {
     const storageString = await AsyncStorage.getItem(TAG)
-    console.log(storageString)
     const storage = storageString ? JSON.parse(storageString) : {}
-    console.log('GETTING STORAGE', storage[this.walletId], this.walletId, storage)
-
     return storage[this.walletId] as string
   }
 

--- a/src/capsule/PrivateKeyStorage.ts
+++ b/src/capsule/PrivateKeyStorage.ts
@@ -1,7 +1,7 @@
 export abstract class PrivateKeyStorage {
   public walletId: string
 
-  public abstract setPrivateKey(key: string): undefined
+  public abstract setPrivateKey(key: string): void
 
   public abstract getPrivateKey(): string
 
@@ -10,13 +10,14 @@ export abstract class PrivateKeyStorage {
   }
 }
 
-// TODO
+const PseudoKeychain = new Map<string, string>()
+
 export class PrivateKeyStorageDefault extends PrivateKeyStorage {
   getPrivateKey(): string {
-    return ''
+    return PseudoKeychain.get(this.walletId) as string
   }
 
-  setPrivateKey(key: string): undefined {
-    return undefined
+  setPrivateKey(key: string): void {
+    PseudoKeychain.set(this.walletId, key)
   }
 }

--- a/src/capsule/SignersStorage.ts
+++ b/src/capsule/SignersStorage.ts
@@ -1,0 +1,21 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+export abstract class SignersStorage {
+  public abstract addAccount(account: string): Promise<void>
+  public abstract getAccounts(): Promise<string[]>
+}
+
+const TAG = '@CAPSULE/ACCOUNTS'
+
+export class ReactNativeSignersStorage extends SignersStorage {
+  public async addAccount(account: string): Promise<void> {
+    const accounts = await this.getAccounts()
+    accounts.push(account)
+    await AsyncStorage.setItem(TAG, JSON.stringify(accounts))
+  }
+
+  public async getAccounts(): Promise<string[]> {
+    const accountsString = await AsyncStorage.getItem(TAG)
+    return (accountsString ? JSON.parse(accountsString) : []) as string[]
+  }
+}

--- a/src/web3/contracts.ts
+++ b/src/web3/contracts.ts
@@ -35,9 +35,9 @@ let contractKit: ContractKit | undefined
 const initContractKitLock = new Lock()
 
 // @ts-ignore
-async function testSigning(newWallet: CapsuleWallet) {
+async function signTestTransaction(newWallet: CapsuleWallet) {
   Logger.debug('TEST SIGNING')
-  const payload: EIP712TypedData = {
+  const PAYLOAD: EIP712TypedData = {
     types: {
       EIP712Domain: [
         { name: 'name', type: 'string' },
@@ -59,7 +59,7 @@ async function testSigning(newWallet: CapsuleWallet) {
   const storage = new ReactNativeSignersStorage()
   const accounts = await storage.getAccounts()
   const address = accounts[0]
-  const signedTypedMessage = await newWallet.signTypedData(address, payload)
+  const signedTypedMessage = await newWallet.signTypedData(address, PAYLOAD)
   Logger.debug(signedTypedMessage)
 }
 
@@ -69,7 +69,7 @@ async function initWallet() {
   Logger.debug(TAG + '@initWallet', 'Created Wallet')
   ValoraAnalytics.track(ContractKitEvents.init_contractkit_get_wallet_finish)
   await newWallet.init()
-  // await testSigning(newWallet)
+  // await signTestTransaction(newWallet)
   ValoraAnalytics.track(ContractKitEvents.init_contractkit_init_wallet_finish)
   return newWallet
 }

--- a/src/web3/contracts.ts
+++ b/src/web3/contracts.ts
@@ -21,6 +21,8 @@ import Logger from 'src/utils/Logger'
 import { getHttpProvider, getIpcProvider } from 'src/web3/providers'
 import { fornoSelector } from 'src/web3/selectors'
 import Web3 from 'web3'
+import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils'
+import { ReactNativeSignersStorage } from '../capsule/SignersStorage'
 
 const TAG = 'web3/contracts'
 // const KIT_INIT_RETRY_DELAY = 2000
@@ -32,12 +34,42 @@ let contractKit: ContractKit | undefined
 
 const initContractKitLock = new Lock()
 
+// @ts-ignore
+async function testSigning(newWallet: CapsuleWallet) {
+  Logger.debug('TEST SIGNING')
+  const payload: EIP712TypedData = {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+      ],
+      Message: [{ name: 'content', type: 'string' }],
+    },
+    domain: {
+      name: 'Valora',
+      version: '1',
+      chainId: 17,
+    },
+    message: {
+      content: 'valora auth message',
+    },
+    primaryType: 'Message',
+  }
+  const storage = new ReactNativeSignersStorage()
+  const accounts = await storage.getAccounts()
+  const address = accounts[0]
+  const signedTypedMessage = await newWallet.signTypedData(address, payload)
+  Logger.debug(signedTypedMessage)
+}
+
 async function initWallet() {
   ValoraAnalytics.track(ContractKitEvents.init_contractkit_get_wallet_start)
   const newWallet = new CapsuleWallet()
   Logger.debug(TAG + '@initWallet', 'Created Wallet')
   ValoraAnalytics.track(ContractKitEvents.init_contractkit_get_wallet_finish)
   await newWallet.init()
+  // await testSigning(newWallet)
   ValoraAnalytics.track(ContractKitEvents.init_contractkit_init_wallet_finish)
   return newWallet
 }

--- a/src/web3/saga.ts
+++ b/src/web3/saga.ts
@@ -308,8 +308,9 @@ export function* createAndAssignCapsuleAccount() {
     let account = ''
     try {
       account = yield call([wallet, wallet.addAccount])
-      const privateKeyShare: string = wallet.getKeyshare(account)
-      yield call(storeCapsuleKeyShare, privateKeyShare, account)
+      void wallet.getKeyshare(account).then((privateKeyShare) => {
+        void storeCapsuleKeyShare(privateKeyShare, account)
+      })
     } catch (e) {
       if (e.message === ErrorMessages.CAPSULE_ACCOUNT_ALREADY_EXISTS) {
         Logger.warn(TAG + '@createAndAssignCapsuleAccount', 'Attempted to import same account')


### PR DESCRIPTION
## Overview
This PR includes changes relating to storing private shares and signers in the Async Storage. 

I decided to put the storing logic inside the `Wallet` entity. This is a different solution that is known from other wallets, but I believe this is a reasonable approach here because, together with signers and shares, we will also introduce biometric storage. Therefore, we have a bit more data to store and we should not rely on wallets to integrate with every storage properly.

I decided to make the approach modular. I decided to create abstract classes for a different type of storage (for private keys and for signers) and immediately follow up with an opinionated implementation tailored for React Native. 
However, from the user's perspective, that is perfectly fine to replace our implementation with any other, better suited for the product. 

### Signers storage
That is the store with public information about signers connected with the given account. Those are stored in the Local Storage, being a default (although maybe suboptimal) solution for React Native Projects. 

### Private keys storage
That is the storage, which is designed to include sensitive information. Namely, we store private shares (secp256k1 shards), which should be hidden under some security measures. Temporarily, I did that also with Local Storage, which is _the wrong_ solution. However, I did it to avoid dealing with the technicalities of native code with accessing the keychain. If that PR is approved and we will have 100% confidence around every piece of the architecture, we will proceed with purely technical work of migrating those data into secure storage. 

### `CapsuleReactNativeWallet` and `CapsuleBaseWallet`.
 That is purely aesthetical change, but it's worth motivating. Since we are not opinionated toward any storage implementation and allow for replacing our implementations and predicting support for different platforms, we extracted out RN-related components. We created the `CapsuleBaseWallet` abstract class with some methods (RN-specific) implemented in the class `CapsuleReactNativeWallet`.

### `BiometricSessionManager`
Biometrics-related things were extracted out with opinionated stuff moved to `CapsuleReactNativeWallet`
 
 
 ## Testing
 In order to test it, please navigate to `contracts.ts` and uncomment  `await testSigning(newWallet)`. After opening the app for the second time, it should be possible to sign the transaction immediately (and see the output in the terminal) 


