### PR TITLE
Keychain 2/2  - storing keyshare

### DIFF
--- a/src/capsule/ChallengeStorage.ts
+++ b/src/capsule/ChallengeStorage.ts
@@ -2,7 +2,8 @@
 import { ec } from 'elliptic'
 // @ts-ignore
 import EllipticSignature from 'elliptic/lib/elliptic/ec/signature'
-import DeviceCrypto, { AccessLevel } from 'react-native-device-crypto'
+import DeviceCrypto, { AccessLevel, BiometryParams } from 'react-native-device-crypto'
+import { KeyCreationParams } from 'react-native-device-crypto/src/index'
 
 export abstract class ChallengeStorage {
   protected userId: string
@@ -26,14 +27,29 @@ export interface Signature {
 const PEM_HEADER = '-----BEGIN PUBLIC KEY-----'
 const PEM_FOOTER = '-----END PUBLIC KEY-----'
 export class ChallengeReactNativeStorage extends ChallengeStorage {
+  protected signOptions(): BiometryParams {
+    return {
+      biometryTitle: 'Authenticate',
+      biometrySubTitle: 'Signing',
+      biometryDescription: 'Authenticate yourself to sign the text',
+    }
+  }
+
+  protected asymmetricKeyOptions(): KeyCreationParams {
+    return {
+      accessLevel: AccessLevel.ALWAYS,
+      invalidateOnNewBiometry: false,
+    }
+  }
+
   private storageIdentifier() {
     return 'challenge-' + this.userId
   }
   async getPublicKey(): Promise<string> {
-    const pemPublicKey = await DeviceCrypto.getOrCreateAsymmetricKey(this.storageIdentifier(), {
-      accessLevel: AccessLevel.ALWAYS,
-      invalidateOnNewBiometry: false,
-    })
+    const pemPublicKey = await DeviceCrypto.getOrCreateAsymmetricKey(
+      this.storageIdentifier(),
+      this.asymmetricKeyOptions()
+    )
 
     const base64PublicKey = pemPublicKey.replace(PEM_FOOTER, '').replace(PEM_HEADER, '').trim()
     const bufferPublicKey = Buffer.from(base64PublicKey, 'base64')
@@ -43,11 +59,11 @@ export class ChallengeReactNativeStorage extends ChallengeStorage {
   }
 
   async signChallenge(message: string): Promise<Signature> {
-    const signatureDERBase64 = await DeviceCrypto.sign(this.storageIdentifier(), message, {
-      biometryTitle: 'Authenticate',
-      biometrySubTitle: 'Signing',
-      biometryDescription: 'Authenticate yourself to sign the text',
-    })
+    const signatureDERBase64 = await DeviceCrypto.sign(
+      this.storageIdentifier(),
+      message,
+      this.signOptions()
+    )
 
     const signatureDERBuffer = Buffer.from(signatureDERBase64, 'base64')
     const signatureDERHex = signatureDERBuffer.toString('hex')

--- a/src/capsule/PrivateKeyStorage.ts
+++ b/src/capsule/PrivateKeyStorage.ts
@@ -1,31 +1,82 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
+import Keychain from 'react-native-keychain'
+import Logger from '../utils/Logger'
 
 export abstract class PrivateKeyStorage {
   public walletId: string
 
   public abstract setPrivateKey(key: string): Promise<void>
 
-  public abstract getPrivateKey(): Promise<string>
+  public abstract getPrivateKey(): Promise<string | null>
 
   public constructor(walletId: string) {
     this.walletId = walletId
   }
 }
 
-// TODO make it a real keychain
-const TAG = '@CAPSULE/TODO-KEYCHAIN'
+const KEYCHAIN_USER_CANCELLED_ERRORS = [
+  'user canceled the operation',
+  'error: code: 13, msg: cancel',
+  'error: code: 10, msg: fingerprint operation canceled by the user',
+]
+
+export function isUserCancelledError(error: Error) {
+  return KEYCHAIN_USER_CANCELLED_ERRORS.some((userCancelledError) =>
+    error.toString().toLowerCase().includes(userCancelledError)
+  )
+}
+
+export async function storeItem(key: string, value: string, options: Keychain.Options = {}) {
+  try {
+    const result = await Keychain.setGenericPassword('@CAPSULE', value, {
+      service: key,
+      accessible: Keychain.ACCESSIBLE.ALWAYS_THIS_DEVICE_ONLY,
+      rules: Keychain.SECURITY_RULES.NONE,
+      ...options,
+    })
+    if (result === false) {
+      throw new Error('Store result false')
+    }
+  } catch (error) {
+    Logger.error(TAG, 'Error storing item', error, true, value)
+    throw error
+  }
+}
+
+export async function retrieveStoredItem(key: string, options: Keychain.Options = {}) {
+  try {
+    const item = await Keychain.getGenericPassword({
+      service: key,
+      ...options,
+    })
+    if (!item) {
+      return null
+    }
+    return item.password
+  } catch (error) {
+    if (!isUserCancelledError(error)) {
+      // triggered when biometry verification fails and user cancels the action
+      Logger.error(TAG, 'Error retrieving stored item', error, true)
+    }
+    throw error
+  }
+}
+
+const TAG = '@CAPSULE/wallet-'
 
 export class PrivateKeyStorageReactNative extends PrivateKeyStorage {
-  async getPrivateKey(): Promise<string> {
-    const storageString = await AsyncStorage.getItem(TAG)
-    const storage = storageString ? JSON.parse(storageString) : {}
-    return storage[this.walletId] as string
+  protected privateKeyGetOptions(): Keychain.Options {
+    return {}
+  }
+
+  protected privateKeySetOptions(): Keychain.Options {
+    return {}
+  }
+
+  async getPrivateKey(): Promise<string | null> {
+    return await retrieveStoredItem(TAG + this.walletId, this.privateKeyGetOptions())
   }
 
   async setPrivateKey(key: string): Promise<void> {
-    const storageString = await AsyncStorage.getItem(TAG)
-    const storage = storageString ? JSON.parse(storageString) : {}
-    storage[this.walletId] = key
-    return await AsyncStorage.setItem(TAG, JSON.stringify(storage))
+    return await storeItem(TAG + this.walletId, key, this.privateKeySetOptions())
   }
 }

--- a/src/capsule/test/PrivateKeyStorage.test.ts
+++ b/src/capsule/test/PrivateKeyStorage.test.ts
@@ -1,0 +1,17 @@
+import { v4 as uuidv4 } from 'uuid'
+import Logger from '../../utils/Logger'
+import { PrivateKeyStorageReactNative } from '../PrivateKeyStorage'
+
+const privateKeyStoringFlow = async () => {
+  const storage = new PrivateKeyStorageReactNative(uuidv4())
+  const key = uuidv4()
+  await storage.setPrivateKey(key)
+  const obtainedKey = await storage.getPrivateKey()
+  if (obtainedKey === key) {
+    Logger.debug('privateKeyStoringFlow PASSED')
+  } else {
+    Logger.debug('privateKeyStoringFlow FAILED')
+  }
+}
+
+void privateKeyStoringFlow()


### PR DESCRIPTION
Fixes CPSL-54

## Motivation
That is a bit easier part of the keychain integration. We need just to store and retrieve the keyshare.

## Changes
Most of the code is just taken from the Kolektivo keychain class, so it was very straightforward. 

Added tests in a similar way as in the previous PR. 

Also, I added protected functions that are responsible for managing the options (security layers) - not only here but also in the Challenge storage. Potential users will be able to simply extend those classes.  