### PR TITLE
Developer Docs

### DIFF
--- a/capsule/package.json
+++ b/capsule/package.json
@@ -36,7 +36,10 @@
     "release": "release-it",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn install && yarn example pods",
-    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build"
+    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build",
+    "docs": "npx typedoc --plugin typedoc-plugin-markdown --includeVersion --out docs src/CapsuleWallet.ts src/CapsuleSigner.ts",
+    "docs:react": "npx typedoc --plugin typedoc-plugin-markdown --includeVersion --out docs/react-native src/react-native/*",
+    "docs:helpers": "npx typedoc --plugin typedoc-plugin-markdown --includeVersion --out docs/helpers src/helpers.ts"
   },
   "keywords": [
     "react-native",
@@ -74,6 +77,8 @@
     "react-native": "0.71.1",
     "react-native-builder-bob": "^0.20.0",
     "release-it": "^15.0.0",
+    "typedoc": "0.23.24",
+    "typedoc-plugin-markdown": "3.14.0",
     "typescript": "^4.5.2",
     "uuid": "^8.3.0"
   },

--- a/capsule/src/CapsuleSigner.ts
+++ b/capsule/src/CapsuleSigner.ts
@@ -43,7 +43,7 @@ export abstract class CapsuleBaseSigner {
   // ------------- Platform-specific functionalities -------------
   /**
    * Get the instance of the storage for setting and retrieving keyshare secret.
-   * @param address
+   * @param address Address of the account.
    * @protected
    * @category Platform-Specific
    */
@@ -58,9 +58,14 @@ export abstract class CapsuleBaseSigner {
   // ------------- Public methods -------------
 
   /**
-   * 
-   * @param onRecoveryKeyshare 
-   * @returns 
+   * Creates a new 2/3 Capsule account. Uploads encrypted backups to Capsule
+   * server. This will result in the new keyshare persisted
+   * on the device. The recovery keyshare is provided through the callback,
+   * `onRecoveryKeyshare`. 
+   * @param onRecoveryKeyshare The callback that will be passed the recovery 
+   * share. This can be used to securely send the recovery keyshare to the
+   * users email or cloud backup.
+   * @returns Account address.
    * @category Public
    */
   public async generateKeyshare(
@@ -97,11 +102,16 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param recoveryKey 
-   * @param address 
-   * @param onRecoveryKeyshare 
-   * @returns 
+   * Performs the key refresh process with Capsule server. This generates new
+   * keys which make the previous keys for this account unusable. Similar to 
+   * `createAccount`, the new keys are stored on device and the recovery 
+   * keyshare is provided through the callback. 
+   * @param recoveryKey The recovery key sent to the user.
+   * @category Platform-Specific The address of the account to refresh.
+   * @param onRecoveryKeyshare The callback that will be passed the recovery 
+   * share. This can be used to securely send the recovery keyshare to the
+   * users email or cloud backup.
+   * @returns The address of the account.
    * @category Public
    */
   public async refreshKeyshare(
@@ -146,9 +156,13 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param keyshare 
-   * @returns 
+   * Import a previously created account to the wallet. The keyshare can be 
+   * exported from `getKeyshare`. This can be useful for signing in on a new 
+   * device with the same account. This should not be used if the user suspects
+   * the device has been lost or compromised (use `refresh` instead for lost or
+   * compromised keys).
+   * @param keyshare The exported keyshare.
+   * @returns The account address.
    * @category Public
    */
   public async importKeyshare(keyshare: string): Promise<string> {
@@ -159,9 +173,12 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @returns 
+   * Download and decrypt the recovery share from Capsule Server. This is
+   * useful if the user loses access to their recovery share. 
+   * @remarks Note that this will likely require additional authentication
+   * in the future.
+   * @category Platform-Specific Address of the account.
+   * @returns The recovery keyshare of the account.
    * @category Public
    */
   async getRecoveryKey(address: string): Promise<string> {
@@ -185,10 +202,10 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @param tx 
-   * @returns 
+   * Signs and submits a raw transaction using the provided account.
+   * @category Platform-Specific Address of the account.
+   * @param tx Raw transaction to sign.
+   * @returns The RLP encoded transaction with the signature.
    * @category Public
    */
   public async signRawTransaction(
@@ -206,11 +223,11 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @param _addToV 
-   * @param encodedTx 
-   * @returns 
+   * Signs and submits an RLP transaction using the provided account.
+   * @category Platform-Specific Address of the account.
+   * @param _addToV The amount to add to the "v" value.
+   * @param encodedTx The RLP encoded transaction to sign.
+   * @returns The signature.
    * @category Public
    */
   public async signTransaction(
@@ -251,10 +268,10 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @param data 
-   * @returns 
+   * Signs a non-transaction message string.
+   * @param address Address of the account.
+   * @param data The message to sign.
+   * @returns The signed message.
    * @category Public
    */
   public async signPersonalMessage(
@@ -269,10 +286,10 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @param typedData 
-   * @returns 
+   * Signs an EIP-712 typed data message.
+   * @param address Address of the account.
+   * @param typedData Typed data message to sign. 
+   * @returns The signed message.
    * @category Public
    */
   public async signTypedData(
@@ -288,9 +305,10 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @returns 
+   * Retrieve a keyshare that has been loaded into this signer. Useful for
+   * exporting the keyshare onto a new device.
+   * @param address Address of the account.
+   * @returns The serialized keyshare.
    * @category Public
    */
   public async getKeyshare(address: string) {
@@ -301,12 +319,15 @@ export abstract class CapsuleBaseSigner {
   // --------------------------
 
   /**
-   * 
-   * @param userKeyshare 
-   * @param recoveryKeyshare 
-   * @param walletId 
-   * @param onRecoveryKeyshare 
-   * @returns 
+   * Encrypts the user and recovery share using the asymmetric encryption keys
+   * and uploads it to the Capsule server. Stores the user keyshare locally.
+   * @param userKeyshare The user keyshare.
+   * @param recoveryKeyshare The recovery keyshare.
+   * @param walletId The walletId registered with Capsule.
+   * @param onRecoveryKeyshare The callback that will be passed the recovery 
+   * share. This can be used to securely send the recovery keyshare to the
+   * users email or cloud backup.
+   * @returns The account address.
    * @category Private
    */
   private async encryptAndUploadKeys(
@@ -365,13 +386,15 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @param keyContainer 
-   * @returns 
+   * Store the keyContainer locally using the private key storage.
+   * @param address Address of the account.
+   * @param keyContainer The keyContainer to store.
    * @category Private
    */
-  private async setKeyContainer(address: string, keyContainer: KeyContainer) {
+  private async setKeyContainer(
+    address: string,
+    keyContainer: KeyContainer
+  ): Promise<void> {
     const serializedKeyContainer = JSON.stringify(keyContainer);
     return this.getPrivateKeyStorage(address).setPrivateKey(
       serializedKeyContainer
@@ -379,9 +402,9 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param address 
-   * @returns 
+   * Retrieve the key container from the private key storage.
+   * @param address Address of the account.
+   * @returns The keyContainer.
    * @category Private
    */
   private async getKeyContainer(address: string): Promise<KeyContainer> {
@@ -404,10 +427,10 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param userId 
-   * @param address 
-   * @returns 
+   * Get the walletId from the Capsule server using the account address.
+   * @param userId UserId registered with the Capsule Server
+   * @param address Address of the account.
+   * @returns The UserId.
    * @category Private
    */
   private async getWallet(userId: string, address: string): Promise<any> {
@@ -427,11 +450,12 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param userId 
-   * @param walletId 
-   * @param tx 
-   * @returns 
+   * Prepares Capsule Server to sign a message and generates a protocolId for
+   * the signing step.
+   * @param userId UserId registered with the Capsule Server
+   * @param walletId The walletId registered with Capsule.
+   * @param tx The transaction to be signed.
+   * @returns Result with the protocolId property.
    * @category Private
    */
   private async preSignMessage(
@@ -450,10 +474,10 @@ export abstract class CapsuleBaseSigner {
   }
 
   /**
-   * 
-   * @param hash 
-   * @param address 
-   * @returns 
+   * Sign a hash using Capsule.
+   * @param hash The hash to sign.
+   * @param address Address of the account.
+   * @returns The signed hash.
    * @category Private
    */
   private async signHash(

--- a/capsule/src/CapsuleSigner.ts
+++ b/capsule/src/CapsuleSigner.ts
@@ -42,7 +42,7 @@ export abstract class CapsuleBaseSigner {
 
   // ------------- Platform-specific functionalities -------------
   /**
-   * get the instance of the storage for setting and retrieving keyshare secret.
+   * Get the instance of the storage for setting and retrieving keyshare secret.
    * @param address
    * @protected
    * @category Platform-Specific
@@ -50,7 +50,7 @@ export abstract class CapsuleBaseSigner {
   protected abstract getPrivateKeyStorage(address: string): PrivateKeyStorage;
 
   /**
-   * get the instance of the SignerModule for performing the MPC operations
+   * Get the instance of the SignerModule for performing the MPC operations
    * @category Platform-Specific
    */
   protected abstract getSignerModule(): SignerModule;
@@ -164,10 +164,7 @@ export abstract class CapsuleBaseSigner {
    * @returns 
    * @category Public
    */
-  public async getRecoveryKey(
-    address: string,
-    onRecoveryKeyshare: (keyshare: string) => void
-  ): Promise<void> {
+  async getRecoveryKey(address: string): Promise<string> {
     const userKeyContainer = await this.getKeyContainer(address);
     // Get the encrypted keyshares from Capsule server
     const encryptedRecoveryBackup = await requestAndReauthenticate(
@@ -184,7 +181,7 @@ export abstract class CapsuleBaseSigner {
       encryptedRecoveryBackup.data.keyShare.encryptedShare
     );
     
-    await onRecoveryKeyshare?.(recoveryBackup);
+    return recoveryBackup;
   }
 
   /**

--- a/capsule/src/CapsuleWallet.ts
+++ b/capsule/src/CapsuleWallet.ts
@@ -189,7 +189,7 @@ export abstract class CapsuleBaseWallet {
    * device with the same account. This should not be used if the user suspects
    * the device has been lost or compromised (use `refresh` instead for lost or
    * compromised keys).
-   * @param keyshare The exported keyshare
+   * @param keyshare The exported keyshare.
    * @category Public
    */
   public async importAccount(keyshare: string): Promise<string> {
@@ -247,8 +247,9 @@ export abstract class CapsuleBaseWallet {
 
   /**
    * Download and decrypt the recovery share from Capsule Server. This is
-   * useful if the user loses access to their recovery share. Note that this
-   * will likely require additional authentication in the future.
+   * useful if the user loses access to their recovery share. 
+   * @remarks Note that this will likely require additional authentication
+   * in the future.
    * @param address Address of the account.
    * @returns The recovery keyshare of the account.
    * @category Public

--- a/capsule/src/CapsuleWallet.ts
+++ b/capsule/src/CapsuleWallet.ts
@@ -1,4 +1,4 @@
-import { CeloTx } from '@celo/connect';
+import { CeloTx, EncodedTransaction } from '@celo/connect';
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
 import * as ethUtil from 'ethereumjs-util';
 import { ErrorMessages } from './ErrorMessages';
@@ -14,21 +14,42 @@ import { requestAndReauthenticate } from './helpers';
 
 const TAG = 'geth/CapsuleWallet';
 
+/**
+ * CapsuleBaseWallet is the abstract class for managing Capsule Wallets. The 
+ * wallet is extended for platform-specific implementations for account and
+ * sessions storage. CapsuleBaseWallet manages an instance of CapsuleBaseSigner
+ * for performing cryptographic operations. One instance of CapsuleBaseWallet 
+ * may be used to manage multiple Capsule accounts.
+ */
 export abstract class CapsuleBaseWallet {
+  
+  /**
+   * Singleton instance for managing keys and performing crypto operations.
+   */
   private signer: CapsuleBaseSigner | undefined;
+
+  /**
+   * Persistent storage for managing known accounts.
+   */
   private signersStorage = this.getSignersStorage();
+
+  /**
+   * Manages temporary session keys.
+   */
   private sessionManager: SessionManager | undefined;
 
-  // ------------- Platform-specific functionalities -------------
   /**
-   * Get instance of persistent storage for signers
+   * Get instance of persistent storage for signers.
+   * @category Platform-Specific
    * @protected
    */
   protected abstract getSignersStorage(): SignersStorage;
+
   /**
-   * Get signer instance from the userId
-   * @param userId
+   * Get signer instance from the userId.
+   * @param userId UserId registered with the Capsule Server
    * @param ensureSessionActive helper to use by signer if the session is expired
+   * @category Platform-Specific
    * @protected
    */
   protected abstract getCapsuleSigner(
@@ -38,13 +59,15 @@ export abstract class CapsuleBaseWallet {
 
   /**
    * Get storage instance for persisting session public key and signing messages.
-   * @param userId
+   * @param userId UserId registered with the Capsule Server
+   * @category Platform-Specific
    * @protected
    */
   protected abstract getChallengeStorage(userId: string): SessionStorage;
 
   /**
-   * Getter for user id as we do not require its presence while creating wallet.
+   * Getter for userId as we do not require its presence while creating wallet.
+   * Should return the userId from wherever it's stored.
    * @protected
    */
   protected abstract getUserId(): Promise<string>;
@@ -53,17 +76,27 @@ export abstract class CapsuleBaseWallet {
 
   /**
    * Send a public key to the server to allow session refreshing.
-   * Requires usedId to be initialized.
+   * Requires userId to be initialized.
+   * @category Public
    */
   public async initSessionManagement() {
     await this.initSessionManagerIfNeeded();
     await this.sessionManager!.setSessionKey();
   }
 
+  /**
+   * @deprecated
+   * @category Deprecated
+   */
   public init() {
     console.warn('No need to call init!');
   }
 
+  /**
+   * @deprecated
+   * @param privateKey 
+   * @category Deprecated
+   */
   public addAccount(privateKey: string) {
     console.warn(
       'addAccount is provided for backward compatibility, but use importAccount!'
@@ -71,6 +104,13 @@ export abstract class CapsuleBaseWallet {
     this.importAccount(privateKey);
   }
 
+  /**
+   * @deprecated
+   * @param _account 
+   * @param _passphrase 
+   * @param _duration 
+   * @category Deprecated
+   */
   public async unlockAccount(
     _account: string,
     _passphrase: string,
@@ -81,6 +121,10 @@ export abstract class CapsuleBaseWallet {
     );
   }
 
+  /**
+   * @deprecated
+   * @category Deprecated
+   */
   public isAccountUnlocked(_address: string) {
     console.warn(
       'isAccountUnlocked is provided for backward compatibility, but it is not used!'
@@ -89,10 +133,14 @@ export abstract class CapsuleBaseWallet {
   }
 
   /**
-   * Add account to the wallet. Once initialized with a keyhare, the account is imported to the wallet.
-   * If the keyshare is not provided, the new key account is generated and the recovery keyshare returned with a callback.
-   * @param privateKey
-   * @param onRecoveryKeyshare
+   * Create a new Capsule account. Once initialized with a keyhare, the account
+   * is imported to the wallet. This will result in the new keyshare persisted
+   * on the device. The recovery keyshare is provided through the callback,
+   * `onRecoveryKeyshare`. 
+   * @param onRecoveryKeyshare The callback that will be passed the recovery 
+   * share. This can be used to securely send the recovery keyshare to the
+   * users email or cloud backup.
+   * @category Public
    */
   public async createAccount(
     onRecoveryKeyshare: (keyshare: string) => void
@@ -106,27 +154,43 @@ export abstract class CapsuleBaseWallet {
     return address;
   }
 
+  /**
+   * Performs the key refresh process with Capsule server. This generates new
+   * keys which make the previous keys for this account unusable. Similar to 
+   * `createAccount`, the new keys are stored on device and the recovery 
+   * keyshare is provided through the callback. 
+   * @param keyshare One of user-custodied keyshares (either the device keyshare
+   * or the recovery keyshare)
+   * @param onRecoveryKeyshare The callback that will be passed the recovery
+   * share. This can be used to securely send the recovery keyshare to the
+   * users email or cloud backup.
+   * @category Public
+   */
   public async refresh(
-    address: string,
     keyshare: string,
     onRecoveryKeyshare: (keyshare: string) => void
   ) {
     const signer = await this.getSigner();
+    const address = await signer.importKeyshare(keyshare);
     await signer.refreshKeyshare(keyshare, address, onRecoveryKeyshare);
   }
 
   /**
-   * @returns The addresses of all accounts that have been created with this wallet
+   * @returns The addresses of all accounts that have been created with this wallet.
+   * @category Public
    */
   public async getAccounts(): Promise<string[]> {
     return this.signersStorage.getAccounts();
   }
 
   /**
-   * Add account to the wallet. Once initialized with a keyhare, the account is imported to the wallet.
-   * If the keyshare is not provided, the new key account is generated and the recovery keyshare returned with a callback.
-   * @param privateKey
-   * @param onRecoveryKeyshare
+   * Import a previously created account to the wallet. The keyshare can be 
+   * exported from `getKeyshare`. This can be useful for signing in on a new 
+   * device with the same account. This should not be used if the user suspects
+   * the device has been lost or compromised (use `refresh` instead for lost or
+   * compromised keys).
+   * @param keyshare The exported keyshare
+   * @category Public
    */
   public async importAccount(keyshare: string): Promise<string> {
     const signer = await this.getSigner();
@@ -137,6 +201,18 @@ export abstract class CapsuleBaseWallet {
     return address;
   }
 
+  /**
+   * Uses the `rawRecoveryKeyshare` to download and decrypt the device
+   * keyshare. This should be used when the user loses their device and only
+   * has their backup recovery keyshare. Results in a key refresh.
+   * @param rawRecoveryKeyshare The recovery keyshare originally sent to the
+   * user's backup.
+   * @param onNewRecoveryKeyshare The callback that will be passed the recovery
+   * share. This can be used to securely send the recovery keyshare to the
+   * users email or cloud backup.
+   * @returns The account address.
+   * @category Public
+   */
   public async recoverAccountFromRecoveryKeyshare(
     rawRecoveryKeyshare: string,
     onNewRecoveryKeyshare: (keyshare: string) => void
@@ -170,17 +246,31 @@ export abstract class CapsuleBaseWallet {
     return recoveryKeyshare.address;
   }
 
-  public async getRecoveryShare(address: string): Promise<string> {
+  /**
+   * Download and decrypt the recovery share from Capsule Server. This is
+   * useful if the user loses access to their recovery share.
+   * @param address 
+   * @param onRecoveryKeyshare The callback that will be passed the recovery
+   * share. This can be used to securely send the recovery keyshare to the
+   * users email or cloud backup.
+   * @returns 
+   * @category Public
+   */
+  public async getRecoveryShare(
+    address: string,
+    onRecoveryKeyshare: (keyshare: string) => void
+  ): Promise<void> {
     const signer = await this.getSigner();
-    return await signer.getRecoveryKey(address);
+    return await signer.getRecoveryKey(address, onRecoveryKeyshare);
   }
 
   /**
-   * Signs and sends the transaction to the network
-   * @param txParams Transaction to sign
-   * @dev overrides WalletBase.signTransaction
+   * Signs and sends the transaction to the network.
+   * @param txParams Transaction to sign.
+   * @returns The signed transaction.
+   * @category Public
    */
-  public async signTransaction(txParams: CeloTx) {
+  public async signTransaction(txParams: CeloTx): Promise<EncodedTransaction> {
     logger.info(
       `${TAG}@signTransaction`,
       `Signing transaction: ${JSON.stringify(txParams)}`
@@ -192,10 +282,11 @@ export abstract class CapsuleBaseWallet {
   }
 
   /**
-   * Sign the provided typed data with the given address
-   * @param address The address with which to sign
-   * @param typedData The data to sign
-   * @dev overrides WalletBase.signTypedData
+   * Sign the provided typed data with the given address.
+   * @param address The address with which to sign.
+   * @param typedData The data to sign.
+   * @returns Signed type data.
+   * @category Public
    */
   public async signTypedData(
     address: string,
@@ -213,22 +304,30 @@ export abstract class CapsuleBaseWallet {
 
   /**
    * Export keyshare from the wallet
-   * @param address
+   * @param address The address of the account to get the keyshare of.
+   * @param onDeviceKeyshare The callback that will be passed the device key
+   * share. This can be used to securely send the device keyshare to the
+   * users clipboard or QR code.
+   * @category Public
    */
-  async getKeyshare(address: string): Promise<string> {
+  public async getKeyshare(
+    address: string,
+    onDeviceKeyshare: (keyshare: string) => void
+  ): Promise<void> {
     const signer = await this.getSigner();
     const keyshare = await signer.getKeyshare(address);
     if (!keyshare) {
       logger.error(`${TAG}@addAccount`, `Missing private key`);
       throw new Error(ErrorMessages.CAPSULE_UNEXPECTED_ADDRESS);
     }
-    return keyshare!;
+    await onDeviceKeyshare(keyshare);
   }
 
   // --------------------------
 
   /**
-   * @returns Singleton instance of the Signer
+   * @returns The singleton instance of the Signer.
+   * @category Private
    */
   private async getSigner(): Promise<CapsuleBaseSigner> {
     if (!this.signer) {
@@ -240,7 +339,10 @@ export abstract class CapsuleBaseWallet {
     return this.signer;
   }
 
-  // We initialize the manager late to ensure the userID is available.
+  /**
+   * We initialize the manager late to ensure the userID is available.
+   * @category Private
+   */
   private async initSessionManagerIfNeeded() {
     if (!this.sessionManager) {
       const userId = await this.getUserId();
@@ -254,6 +356,10 @@ export abstract class CapsuleBaseWallet {
     }
   }
 
+  /**
+   * Refreshes the session if it has expired
+   * @category Private
+   */
   private async ensureSessionActive() {
     await this.initSessionManagerIfNeeded();
     await this.sessionManager!.refreshSessionIfNeeded();

--- a/capsule/src/helpers.ts
+++ b/capsule/src/helpers.ts
@@ -6,10 +6,20 @@ import {
   USER_NOT_VERIFIED,
 } from '@capsule/client/client';
 
+/**
+ * Used to convert hex to base64 string.
+ * @param hex The hex string.
+ * @returns The base64 string.
+ */
 export function hexToBase64(hex: string) {
   return Buffer.from(hex.replace('0x', ''), 'hex').toString('base64');
 }
 
+/**
+ * Used to convert base64 to a hex string.
+ * @param base64 The base64 string.
+ * @returns The hex string.
+ */
 export function base64ToHex(base64: string) {
   return ensureLeading0x(Buffer.from(base64, 'base64').toString('hex'));
 }

--- a/capsule/src/react-native/ReactNativeCapsuleSigner.ts
+++ b/capsule/src/react-native/ReactNativeCapsuleSigner.ts
@@ -6,6 +6,9 @@ import { SignerModule } from '../SignerModule';
 
 const { CapsuleSignerModule } = NativeModules;
 
+/**
+ * React Native implementation of Capsule Signer
+ */
 export class ReactNativeCapsuleSigner extends CapsuleBaseSigner {
   protected getSignerModule(): SignerModule {
     return CapsuleSignerModule;

--- a/capsule/src/react-native/ReactNativeCapsuleWallet.ts
+++ b/capsule/src/react-native/ReactNativeCapsuleWallet.ts
@@ -10,6 +10,9 @@ import { ReactNativeSessionStorage } from './ReactNativeSessionStorage';
 
 export const USER_ID_TAG = '@CAPSULE/USER_ID';
 
+/**
+ * React Native implementation of CapsuleWallet
+ */
 export class ReactNativeCapsuleWallet extends CapsuleBaseWallet {
   getCapsuleSigner(
     userId: string,

--- a/capsule/src/react-native/ReactNativePrivateKeyStorage.ts
+++ b/capsule/src/react-native/ReactNativePrivateKeyStorage.ts
@@ -53,6 +53,9 @@ export async function retrieveStoredItem(
 
 const TAG = '@CAPSULE/wallet-';
 
+/**
+ * React Native implementation of PrivateKeyStorage using Keychain
+ */
 export class ReactNativePrivateKeyStorage extends PrivateKeyStorage {
   protected privateKeyGetOptions(): Keychain.Options {
     return {};
@@ -62,14 +65,22 @@ export class ReactNativePrivateKeyStorage extends PrivateKeyStorage {
     return {};
   }
 
-  async getPrivateKey(): Promise<string | null> {
+  /**
+   * Retrieves the private key from KeyChain.
+   * @returns The private key.
+   */
+  public async getPrivateKey(): Promise<string | null> {
     return await retrieveStoredItem(
       TAG + this.walletId,
       this.privateKeyGetOptions()
     );
   }
 
-  async setPrivateKey(key: string): Promise<void> {
+  /**
+   * Stores the private key in KeyChain.
+   * @param key The private key.
+   */
+  public async setPrivateKey(key: string): Promise<void> {
     return await storeItem(
       TAG + this.walletId,
       key,

--- a/capsule/src/react-native/ReactNativeSessionStorage.ts
+++ b/capsule/src/react-native/ReactNativeSessionStorage.ts
@@ -10,6 +10,11 @@ import { SessionStorage, Signature } from '../SessionStorage';
 const PEM_HEADER = '-----BEGIN PUBLIC KEY-----';
 const PEM_FOOTER = '-----END PUBLIC KEY-----';
 
+/**
+ * React Native implementation of SessionStorage
+ * Uses the device key to manage session storage and recreate sessions that
+ * have expired.
+ */
 export class ReactNativeSessionStorage extends SessionStorage {
   protected signOptions(): BiometryParams {
     return {
@@ -30,7 +35,11 @@ export class ReactNativeSessionStorage extends SessionStorage {
     return 'challenge-' + this.userId;
   }
 
-  async getPublicKey(): Promise<string> {
+  /**
+   * Uses the device's enclave to generate or retrieve a session key.
+   * @returns The public key of the challenge signer.
+   */
+  public async getPublicKey(): Promise<string> {
     const pemPublicKey = await DeviceCrypto.getOrCreateAsymmetricKey(
       this.storageIdentifier(),
       this.asymmetricKeyOptions()
@@ -46,7 +55,12 @@ export class ReactNativeSessionStorage extends SessionStorage {
     return publicKeyHex;
   }
 
-  async signChallenge(message: string): Promise<Signature> {
+  /**
+   * Signs a challenge to refresh the session.
+   * @param message The challenge to sign.
+   * @returns The signed challenge.
+   */
+  public async signChallenge(message: string): Promise<Signature> {
     const signatureDERBase64 = await DeviceCrypto.sign(
       this.storageIdentifier(),
       message,

--- a/capsule/src/react-native/ReactNativeSignersStorage.ts
+++ b/capsule/src/react-native/ReactNativeSignersStorage.ts
@@ -3,13 +3,25 @@ import { SignersStorage } from '../SignersStorage';
 
 const TAG = '@CAPSULE/ACCOUNTS';
 
+/**
+ * React Native implementation of SignerStorage
+ * Uses React Native async storage to track accounts. 
+ */
 export class ReactNativeSignersStorage extends SignersStorage {
+  /**
+   * Stores the account in async storage.
+   * @param account Address of the account to store.
+   */
   public async addAccount(account: string): Promise<void> {
     const accounts = await this.getAccounts();
     accounts.push(account);
     await AsyncStorage.setItem(TAG, JSON.stringify(accounts));
   }
 
+  /**
+   * Retrieves the accounts from async storage.
+   * @returns The set of accounts.
+   */
   public async getAccounts(): Promise<string[]> {
     const accountsString = await AsyncStorage.getItem(TAG);
     return (accountsString ? JSON.parse(accountsString) : []) as string[];

--- a/capsule/src/test/KeyRefresh.quasitest.ts
+++ b/capsule/src/test/KeyRefresh.quasitest.ts
@@ -30,7 +30,7 @@ export const keyRefreshFlow = async () => {
   let newRecoveryShare = '';
   await new Promise((resolve) => setTimeout(resolve, 3000));
 
-  await wallet.refresh(address, recoveryShare, (share) => {
+  await wallet.refresh(recoveryShare, (share) => {
     newRecoveryShare = share;
   });
 

--- a/capsule/typedoc.json
+++ b/capsule/typedoc.json
@@ -1,0 +1,3 @@
+{
+    "categoryOrder": ["Platform-Specific", "Public", "Private", "*"]
+}


### PR DESCRIPTION
### Description

Documented all of our customer facing methods and classes. Using the new commands, we can generate docs automatically from our code:
```
yarn docs
yarn docs:react
yarn docs:helpers
```

### Other changes

Small change to `refresh` interface to not require the address since we can derive it from the provided share.


### Example doc using CapsuleWallet
[@usecapsule/react-native-wallet - v0.1.6](../README.md) / [Modules](../modules.md) / [CapsuleWallet](../modules/CapsuleWallet.md) / CapsuleBaseWallet

# Class: CapsuleBaseWallet

[CapsuleWallet](../modules/CapsuleWallet.md).CapsuleBaseWallet

CapsuleBaseWallet is the abstract class for managing Capsule Wallets. The 
wallet is extended for platform-specific implementations for account and
sessions storage. CapsuleBaseWallet manages an instance of CapsuleBaseSigner
for performing cryptographic operations. One instance of CapsuleBaseWallet 
may be used to manage multiple Capsule accounts.

## Table of contents

### Constructors

- [constructor](CapsuleWallet.CapsuleBaseWallet.md#constructor)

### Properties

- [sessionManager](CapsuleWallet.CapsuleBaseWallet.md#sessionmanager)
- [signer](CapsuleWallet.CapsuleBaseWallet.md#signer)
- [signersStorage](CapsuleWallet.CapsuleBaseWallet.md#signersstorage)

### Platform-Specific Methods

- [getCapsuleSigner](CapsuleWallet.CapsuleBaseWallet.md#getcapsulesigner)
- [getChallengeStorage](CapsuleWallet.CapsuleBaseWallet.md#getchallengestorage)
- [getSignersStorage](CapsuleWallet.CapsuleBaseWallet.md#getsignersstorage)

### Public Methods

- [createAccount](CapsuleWallet.CapsuleBaseWallet.md#createaccount)
- [getAccounts](CapsuleWallet.CapsuleBaseWallet.md#getaccounts)
- [getKeyshare](CapsuleWallet.CapsuleBaseWallet.md#getkeyshare)
- [getRecoveryShare](CapsuleWallet.CapsuleBaseWallet.md#getrecoveryshare)
- [importAccount](CapsuleWallet.CapsuleBaseWallet.md#importaccount)
- [initSessionManagement](CapsuleWallet.CapsuleBaseWallet.md#initsessionmanagement)
- [recoverAccountFromRecoveryKeyshare](CapsuleWallet.CapsuleBaseWallet.md#recoveraccountfromrecoverykeyshare)
- [refresh](CapsuleWallet.CapsuleBaseWallet.md#refresh)
- [signTransaction](CapsuleWallet.CapsuleBaseWallet.md#signtransaction)
- [signTypedData](CapsuleWallet.CapsuleBaseWallet.md#signtypeddata)

### Private Methods

- [ensureSessionActive](CapsuleWallet.CapsuleBaseWallet.md#ensuresessionactive)
- [getSigner](CapsuleWallet.CapsuleBaseWallet.md#getsigner)
- [initSessionManagerIfNeeded](CapsuleWallet.CapsuleBaseWallet.md#initsessionmanagerifneeded)

### Deprecated Methods

- [addAccount](CapsuleWallet.CapsuleBaseWallet.md#addaccount)
- [init](CapsuleWallet.CapsuleBaseWallet.md#init)
- [isAccountUnlocked](CapsuleWallet.CapsuleBaseWallet.md#isaccountunlocked)
- [unlockAccount](CapsuleWallet.CapsuleBaseWallet.md#unlockaccount)

### Other Methods

- [getUserId](CapsuleWallet.CapsuleBaseWallet.md#getuserid)

## Constructors

### constructor

• **new CapsuleBaseWallet**()

## Properties

### sessionManager

• `Private` **sessionManager**: `undefined` \| `default`

Manages temporary session keys.

#### Defined in

[CapsuleWallet.ts:39](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L39)

___

### signer

• `Private` **signer**: `undefined` \| [`CapsuleBaseSigner`](CapsuleSigner.CapsuleBaseSigner.md)

Singleton instance for managing keys and performing crypto operations.

#### Defined in

[CapsuleWallet.ts:29](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L29)

___

### signersStorage

• `Private` **signersStorage**: `SignersStorage`

Persistent storage for managing known accounts.

#### Defined in

[CapsuleWallet.ts:34](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L34)

## Platform-Specific Methods

### getCapsuleSigner

▸ `Protected` `Abstract` **getCapsuleSigner**(`userId`, `ensureSessionActive`): [`CapsuleBaseSigner`](CapsuleSigner.CapsuleBaseSigner.md)

Get signer instance from the userId.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `userId` | `string` | UserId registered with the Capsule Server |
| `ensureSessionActive` | () => `Promise`<`void`\> | helper to use by signer if the session is expired |

#### Returns

[`CapsuleBaseSigner`](CapsuleSigner.CapsuleBaseSigner.md)

#### Defined in

[CapsuleWallet.ts:55](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L55)

___

### getChallengeStorage

▸ `Protected` `Abstract` **getChallengeStorage**(`userId`): `SessionStorage`

Get storage instance for persisting session public key and signing messages.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `userId` | `string` | UserId registered with the Capsule Server |

#### Returns

`SessionStorage`

#### Defined in

[CapsuleWallet.ts:66](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L66)

___

### getSignersStorage

▸ `Protected` `Abstract` **getSignersStorage**(): `SignersStorage`

Get instance of persistent storage for signers.

#### Returns

`SignersStorage`

#### Defined in

[CapsuleWallet.ts:46](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L46)

___

## Public Methods

### createAccount

▸ **createAccount**(`onRecoveryKeyshare`): `Promise`<`string`\>

Create a new Capsule account. Once initialized with a keyhare, the account
is imported to the wallet. This will result in the new keyshare persisted
on the device. The recovery keyshare is provided through the callback,
`onRecoveryKeyshare`.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `onRecoveryKeyshare` | (`keyshare`: `string`) => `void` | The callback that will be passed the recovery share. This can be used to securely send the recovery keyshare to the users email or cloud backup. |

#### Returns

`Promise`<`string`\>

#### Defined in

[CapsuleWallet.ts:145](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L145)

___

### getAccounts

▸ **getAccounts**(): `Promise`<`string`[]\>

#### Returns

`Promise`<`string`[]\>

The addresses of all accounts that have been created with this wallet.

#### Defined in

[CapsuleWallet.ts:182](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L182)

___

### getKeyshare

▸ **getKeyshare**(`address`): `Promise`<`string`\>

Export keyshare from the wallet

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `address` | `string` | The address of the account to get the keyshare of. |

#### Returns

`Promise`<`string`\>

The keyshare of the account.

#### Defined in

[CapsuleWallet.ts:306](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L306)

___

### getRecoveryShare

▸ **getRecoveryShare**(`address`): `Promise`<`string`\>

Download and decrypt the recovery share from Capsule Server. This is
useful if the user loses access to their recovery share.

**`Remarks`**

Note that this will likely require additional authentication
in the future.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `address` | `string` | Address of the account. |

#### Returns

`Promise`<`string`\>

The recovery keyshare of the account.

#### Defined in

[CapsuleWallet.ts:257](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L257)

___

### importAccount

▸ **importAccount**(`keyshare`): `Promise`<`string`\>

Import a previously created account to the wallet. The keyshare can be 
exported from `getKeyshare`. This can be useful for signing in on a new 
device with the same account. This should not be used if the user suspects
the device has been lost or compromised (use `refresh` instead for lost or
compromised keys).

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `keyshare` | `string` | The exported keyshare. |

#### Returns

`Promise`<`string`\>

#### Defined in

[CapsuleWallet.ts:195](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L195)

___

### initSessionManagement

▸ **initSessionManagement**(): `Promise`<`void`\>

Send a public key to the server to allow session refreshing.
Requires userId to be initialized.

#### Returns

`Promise`<`void`\>

#### Defined in

[CapsuleWallet.ts:82](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L82)

___

### recoverAccountFromRecoveryKeyshare

▸ **recoverAccountFromRecoveryKeyshare**(`rawRecoveryKeyshare`, `onNewRecoveryKeyshare`): `Promise`<`string`\>

Uses the `rawRecoveryKeyshare` to download and decrypt the device
keyshare. This should be used when the user loses their device and only
has their backup recovery keyshare. Results in a key refresh.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `rawRecoveryKeyshare` | `string` | The recovery keyshare originally sent to the user's backup. |
| `onNewRecoveryKeyshare` | (`keyshare`: `string`) => `void` | The callback that will be passed the recovery share. This can be used to securely send the recovery keyshare to the users email or cloud backup. |

#### Returns

`Promise`<`string`\>

The account address.

#### Defined in

[CapsuleWallet.ts:216](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L216)

___

### refresh

▸ **refresh**(`rawKeyshare`, `onRecoveryKeyshare`): `Promise`<`void`\>

Performs the key refresh process with Capsule server. This generates new
keys which make the previous keys for this account unusable. Similar to 
`createAccount`, the new keys are stored on device and the recovery 
keyshare is provided through the callback.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `rawKeyshare` | `string` | - |
| `onRecoveryKeyshare` | (`keyshare`: `string`) => `void` | The callback that will be passed the recovery share. This can be used to securely send the recovery keyshare to the users email or cloud backup. |

#### Returns

`Promise`<`void`\>

#### Defined in

[CapsuleWallet.ts:169](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L169)

___

### signTransaction

▸ **signTransaction**(`txParams`): `Promise`<`EncodedTransaction`\>

Signs and sends the transaction to the network.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `txParams` | `any` | Transaction to sign. |

#### Returns

`Promise`<`EncodedTransaction`\>

The signed transaction.

#### Defined in

[CapsuleWallet.ts:268](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L268)

___

### signTypedData

▸ **signTypedData**(`address`, `typedData`): `Promise`<`string`\>

Sign the provided typed data with the given address.

#### Parameters

| Name | Type | Description |
| :------ | :------ | :------ |
| `address` | `string` | The address with which to sign. |
| `typedData` | `EIP712TypedData` | The data to sign. |

#### Returns

`Promise`<`string`\>

Signed type data.

#### Defined in

[CapsuleWallet.ts:286](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L286)

___

## Private Methods

### ensureSessionActive

▸ `Private` **ensureSessionActive**(): `Promise`<`void`\>

Refreshes the session if it has expired

#### Returns

`Promise`<`void`\>

#### Defined in

[CapsuleWallet.ts:353](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L353)

___

### getSigner

▸ `Private` **getSigner**(): `Promise`<[`CapsuleBaseSigner`](CapsuleSigner.CapsuleBaseSigner.md)\>

#### Returns

`Promise`<[`CapsuleBaseSigner`](CapsuleSigner.CapsuleBaseSigner.md)\>

The singleton instance of the Signer.

#### Defined in

[CapsuleWallet.ts:322](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L322)

___

### initSessionManagerIfNeeded

▸ `Private` **initSessionManagerIfNeeded**(): `Promise`<`void`\>

We initialize the manager late to ensure the userID is available.

#### Returns

`Promise`<`void`\>

#### Defined in

[CapsuleWallet.ts:336](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L336)

___

## Deprecated Methods

### addAccount

▸ **addAccount**(`privateKey`): `void`

**`Deprecated`**

#### Parameters

| Name | Type |
| :------ | :------ |
| `privateKey` | `string` |

#### Returns

`void`

#### Defined in

[CapsuleWallet.ts:100](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L100)

___

### init

▸ **init**(): `void`

**`Deprecated`**

#### Returns

`void`

#### Defined in

[CapsuleWallet.ts:91](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L91)

___

### isAccountUnlocked

▸ **isAccountUnlocked**(`_address`): `boolean`

**`Deprecated`**

#### Parameters

| Name | Type |
| :------ | :------ |
| `_address` | `string` |

#### Returns

`boolean`

#### Defined in

[CapsuleWallet.ts:128](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L128)

___

### unlockAccount

▸ **unlockAccount**(`_account`, `_passphrase`, `_duration`): `Promise`<`void`\>

**`Deprecated`**

#### Parameters

| Name | Type |
| :------ | :------ |
| `_account` | `string` |
| `_passphrase` | `string` |
| `_duration` | `number` |

#### Returns

`Promise`<`void`\>

#### Defined in

[CapsuleWallet.ts:114](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L114)

___

## Other Methods

### getUserId

▸ `Protected` `Abstract` **getUserId**(): `Promise`<`string`\>

Getter for userId as we do not require its presence while creating wallet.
Should return the userId from wherever it's stored.

#### Returns

`Promise`<`string`\>

#### Defined in

[CapsuleWallet.ts:73](https://github.com/capsule-org/kolektivo-wallet/blob/4346249fb/capsule/src/CapsuleWallet.ts#L73)
